### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/masterwisniewsk/f18276e7-93ef-4dda-9886-ce2dd6e8e796/4d2a097f-a84e-4890-a978-1ab7ac7197dd/_apis/work/boardbadge/5d4b68c0-e83e-405c-b80e-1e7aac310a81)](https://dev.azure.com/masterwisniewsk/f18276e7-93ef-4dda-9886-ce2dd6e8e796/_boards/board/t/4d2a097f-a84e-4890-a978-1ab7ac7197dd/Microsoft.RequirementCategory)
 # 2062920629842-
 KLIENT ×\} ¢¥] ÷;`
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.